### PR TITLE
Add rpc category

### DIFF
--- a/README.md
+++ b/README.md
@@ -65,19 +65,20 @@ defi
 dex
 exchange
 explorer
+fund
 game
 governance
 infra
+investmentfund
+metaplex
+nft
 oracle
+rpc
 sdk
 spl
 stablecoin
 tools
-metaplex
-nft
 wallet
-fund
-investmentfund
 ```
 
 Please only use existing ones and *watch out for typos*!  


### PR DESCRIPTION
We need to encourage the community to use their own RPC service instead of overloading api.mainnet-beta. This PR adds `rpc` as a category to aid in discoverability of these services. Site visitors will be able to search for `rpc` to find providers or we can deep link from other sites like so: https://solana.com/ecosystem?categories=rpc

Once this lands we need RPC providers to add this new category to their markdown files.