### PR TITLE
Fix multi-msg lint & updated build

### DIFF
--- a/.github/workflows/file-lint.yaml
+++ b/.github/workflows/file-lint.yaml
@@ -31,7 +31,7 @@ jobs:
       # This will lint all files, see https://github.com/timhagn/lint-md-fm
       - name: Lint Current PR
         id: lint
-        uses: timhagn/lint-md-fm@v1.1.6
+        uses: timhagn/lint-md-fm@v1.2.0
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           changed-files: ${{ steps.changed_files.outputs.all_modified_files }}


### PR DESCRIPTION
This PR fixes the forgotten build bump in v1.1.6 of the linter & adds the possibility for multiple combined comments.